### PR TITLE
ZEP-1758: update timezone

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,0 @@
-<!--
-⚠️ 🚨 ⚠️  STOP AND READ THIS ⚠️ 🚨 ⚠️
-
-👆👆 see that 'base fork' dropdown above? You should change it! The default value of "slatedocs/slate" submits your change to ALL USERS OF SLATE, not just your company. This is PROBABLY NOT WHAT YOU WANT.
--->

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -41,7 +41,7 @@ And for all kinds of How To's and Recipes, head on over to our [Help Guide](http
 * Data is sent and received as JSON.
 * Clients should include the `Accepts: application/json` header in their requests.
 * Currencies are represented by 3 characters as defined in [ISO 4217](http://www.xe.com/iso4217.php).
-* Dates & times are returned in UTC using [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format with second accuracy. With requests, when no TZ is supplied, the configured TZ of the authenticated user is used, or `Australia/Sydney` if no TZ is configured.
+* Dates & times are returned in UTC using [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format with second accuracy. With requests, when no TZ is supplied, the configured TZ of the authenticated user is used, or `Pacific/Auckland` if no TZ is configured.
 * Amounts are always in cents with no decimals unless otherwise stated.
 * Zepto provides static public IP addresses for all outbound traffic, including webhooks.
     * Sandbox IP: `13.237.142.60`

--- a/source/openapi3/split.yaml
+++ b/source/openapi3/split.yaml
@@ -51,7 +51,7 @@ info:
     * Dates & times are returned in UTC using [ISO
     8601](https://en.wikipedia.org/wiki/ISO_8601) format with second accuracy.
     With requests, when no TZ is supplied, the configured TZ of the
-    authenticated user is used, or `Australia/Sydney` if no TZ is configured.
+    authenticated user is used, or `Pacific/Auckland` if no TZ is configured.
 
     * Amounts are always in cents with no decimals unless otherwise stated.
 


### PR DESCRIPTION
## 👀 Reviewers

## 💡 Why
* [ZEP-1758](https://zeptoau.atlassian.net/browse/ZEP-1758)

## 📝 What

1. Change any Australia/Sydney references to Pacific/Auckland
2. Searched for any other references to Australia that needs to be changed, search terms include:    
   1. All state acronyms (eg. NSW, VIC, etc)
   2. Different versions of Australia (eg. Aus, Auz, OZ, etc)
   3. GMT +XX

## 💭 Discussion

Found some references to NSW and have included this in [ZEP-1768](https://zeptoau.atlassian.net/browse/ZEP-1768) which I'll also be tackling