### PR TITLE
ZEP-1768: update example banks

### DIFF
--- a/source/index.html.md
+++ b/source/index.html.md
@@ -748,7 +748,7 @@ Zepto provides a `Split-Request-ID` header in the form of a `UUID` which uniquel
 > Example header
 
 ```
-Split-Signature: 1514772000.93eee90206280b25e82b38001e23961cba4c007f4d925ba71ecc2d9804978635
+Split-Signature: 1514772000.93eee90206280b25e82b38001e23961ASB4c007f4d925ba71ecc2d9804978635
 ```
 
 Zepto signs the webhook events it sends to your endpoints. We do so by including a signature in each event’s `Split-Signature` header. This allows you to validate that the events were indeed sent by Zepto.
@@ -1932,8 +1932,8 @@ By default, all Bank Connections will be returned. You can apply filters to your
       "removed_at": null,
       "failure_reason": null,
       "institution": {
-        "short_name": "CBA",
-        "full_name": "Commonwealth Bank of Australia"
+        "short_name": "ASB",
+        "full_name": "Auckland Savings Bank"
       },
       "contact": {
         "id": "626e15b1-aa4a-496e-b5d6-3f8c1a6d2189",
@@ -1952,8 +1952,8 @@ By default, all Bank Connections will be returned. You can apply filters to your
       "removed_at": null,
       "failure_reason": null,
       "institution": {
-        "short_name": "CBA",
-        "full_name": "Commonwealth Bank of Australia"
+        "short_name": "ASB",
+        "full_name": "Auckland Savings Bank"
       },
       "contact": {
         "id": "72e37667-6364-440f-b1bd-56df5654e258",
@@ -2132,8 +2132,8 @@ Get a single Bank Connection by its ID
     "removed_at": null,
     "failure_reason": null,
     "institution": {
-      "short_name": "CBA",
-      "full_name": "Commonwealth Bank of Australia"
+      "short_name": "ASB",
+      "full_name": "Auckland Savings Bank"
     },
     "contact": {
       "id": "72e37667-6364-440f-b1bd-56df5654e258",
@@ -10843,8 +10843,8 @@ Use this endpoint to resend a failed webhook delivery.
       "removed_at": null,
       "failure_reason": null,
       "institution": {
-        "short_name": "CBA",
-        "full_name": "Commonwealth Bank of Australia"
+        "short_name": "ASB",
+        "full_name": "Auckland Savings Bank"
       },
       "contact": {
         "id": "626e15b1-aa4a-496e-b5d6-3f8c1a6d2189",
@@ -10863,8 +10863,8 @@ Use this endpoint to resend a failed webhook delivery.
       "removed_at": null,
       "failure_reason": null,
       "institution": {
-        "short_name": "CBA",
-        "full_name": "Commonwealth Bank of Australia"
+        "short_name": "ASB",
+        "full_name": "Auckland Savings Bank"
       },
       "contact": {
         "id": "72e37667-6364-440f-b1bd-56df5654e258",
@@ -11446,8 +11446,8 @@ Use this endpoint to resend a failed webhook delivery.
     "removed_at": null,
     "failure_reason": null,
     "institution": {
-      "short_name": "CBA",
-      "full_name": "Commonwealth Bank of Australia"
+      "short_name": "ASB",
+      "full_name": "Auckland Savings Bank"
     },
     "contact": {
       "id": "72e37667-6364-440f-b1bd-56df5654e258",

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -1711,7 +1711,7 @@ By default, all Bank Accounts will be returned.
       "bank_name": "Bank of New Zealand",
       "account_number": "3993013",
       "status": "active",
-      "title": "AU.493192.3993013",
+      "title": "NZ.493192.3993013",
       "available_balance": null
     },
     {
@@ -10789,7 +10789,7 @@ Use this endpoint to resend a failed webhook delivery.
       "bank_name": "Bank of New Zealand",
       "account_number": "3993013",
       "status": "active",
-      "title": "AU.493192.3993013",
+      "title": "NZ.493192.3993013",
       "available_balance": null
     },
     {

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -9897,7 +9897,6 @@ func main() {
       "phone": "0418495033",
       "street_address": "98 Acme Avenue",
       "suburb": "Lead",
-      "state": "NSW",
       "postcode": "2478"
     }
   }
@@ -12722,7 +12721,6 @@ Use this endpoint to resend a failed webhook delivery.
       "phone": "0418495033",
       "street_address": "98 Acme Avenue",
       "suburb": "Lead",
-      "state": "NSW",
       "postcode": "2478"
     }
   }

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -41,7 +41,7 @@ And for all kinds of How To's and Recipes, head on over to our [Help Guide](http
 * Data is sent and received as JSON.
 * Clients should include the `Accepts: application/json` header in their requests.
 * Currencies are represented by 3 characters as defined in [ISO 4217](http://www.xe.com/iso4217.php).
-* Dates & times are returned in UTC using [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format with second accuracy. With requests, when no TZ is supplied, the configured TZ of the authenticated user is used, or `Australia/Sydney` if no TZ is configured.
+* Dates & times are returned in UTC using [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format with second accuracy. With requests, when no TZ is supplied, the configured TZ of the authenticated user is used, or `Pacific/Auckland` if no TZ is configured.
 * Amounts are always in cents with no decimals unless otherwise stated.
 * Zepto provides static public IP addresses for all outbound traffic, including webhooks.
     * Sandbox IP: `13.237.142.60`
@@ -1708,7 +1708,7 @@ By default, all Bank Accounts will be returned.
     {
       "id": "6a7ed958-f1e8-42dc-8c02-3901d7057357",
       "branch_code": "493192",
-      "bank_name": "National Australia Bank",
+      "bank_name": "Bank of New Zealand",
       "account_number": "3993013",
       "status": "active",
       "title": "AU.493192.3993013",
@@ -1717,7 +1717,7 @@ By default, all Bank Accounts will be returned.
     {
       "id": "56df206a-aaff-471a-b075-11882bc8906a",
       "branch_code": "302193",
-      "bank_name": "National Australia Bank",
+      "bank_name": "Bank of New Zealand",
       "account_number": "119302",
       "status": "active",
       "title": "Trust Account",
@@ -2515,7 +2515,7 @@ Use this endpoint when you want to pay somebody.
       "id": "55afddde-4296-4daf-8e49-7ba481ef9608",
       "account_number": "13048322",
       "branch_code": "123456",
-      "bank_name": "National Australia Bank",
+      "bank_name": "Bank of New Zealand",
       "state": "active",
       "iav_provider": null,
       "iav_status": null,
@@ -2704,7 +2704,7 @@ By default, all Contacts will be returned. You can apply filters to your query t
         "id": "095c5ab7-7fa8-40fd-b317-cddbbf4c8fbc",
         "account_number": "494307",
         "branch_code": "435434",
-        "bank_name": "National Australia Bank",
+        "bank_name": "Bank of New Zealand",
         "state": "active",
         "iav_provider": "split",
         "iav_status": "active",
@@ -2726,7 +2726,7 @@ By default, all Contacts will be returned. You can apply filters to your query t
         "id": "861ff8e4-7acf-4897-9e53-e7c5ae5f7cc0",
         "account_number": "4395959",
         "branch_code": "068231",
-        "bank_name": "National Australia Bank",
+        "bank_name": "Bank of New Zealand",
         "state": "active",
         "iav_provider": "split",
         "iav_status": "credentials_invalid",
@@ -2770,7 +2770,7 @@ By default, all Contacts will be returned. You can apply filters to your query t
         "id": "55afddde-4296-4daf-8e49-7ba481ef9608",
         "account_number": "13048322",
         "branch_code": "123456",
-        "bank_name": "National Australia Bank",
+        "bank_name": "Bank of New Zealand",
         "state": "pending_verification",
         "iav_provider": null,
         "iav_status": null,
@@ -2957,7 +2957,7 @@ Get a single Contact by its ID
       "id": "fcabeacb-2ef6-4b27-ba19-4f6fa0d57dcb",
       "account_number": "947434694",
       "branch_code": "304304",
-      "bank_name": "National Australia Bank",
+      "bank_name": "Bank of New Zealand",
       "state": "active",
       "iav_provider": null,
       "iav_status": null,
@@ -10786,7 +10786,7 @@ Use this endpoint to resend a failed webhook delivery.
     {
       "id": "6a7ed958-f1e8-42dc-8c02-3901d7057357",
       "branch_code": "493192",
-      "bank_name": "National Australia Bank",
+      "bank_name": "Bank of New Zealand",
       "account_number": "3993013",
       "status": "active",
       "title": "AU.493192.3993013",
@@ -10795,7 +10795,7 @@ Use this endpoint to resend a failed webhook delivery.
     {
       "id": "56df206a-aaff-471a-b075-11882bc8906a",
       "branch_code": "302193",
-      "bank_name": "National Australia Bank",
+      "bank_name": "Bank of New Zealand",
       "account_number": "119302",
       "status": "active",
       "title": "Trust Account",
@@ -11269,7 +11269,7 @@ Use this endpoint to resend a failed webhook delivery.
         "id": "095c5ab7-7fa8-40fd-b317-cddbbf4c8fbc",
         "account_number": "494307",
         "branch_code": "435434",
-        "bank_name": "National Australia Bank",
+        "bank_name": "Bank of New Zealand",
         "state": "active",
         "iav_provider": "split",
         "iav_status": "active",
@@ -11291,7 +11291,7 @@ Use this endpoint to resend a failed webhook delivery.
         "id": "861ff8e4-7acf-4897-9e53-e7c5ae5f7cc0",
         "account_number": "4395959",
         "branch_code": "068231",
-        "bank_name": "National Australia Bank",
+        "bank_name": "Bank of New Zealand",
         "state": "active",
         "iav_provider": "split",
         "iav_status": "credentials_invalid",
@@ -11335,7 +11335,7 @@ Use this endpoint to resend a failed webhook delivery.
         "id": "55afddde-4296-4daf-8e49-7ba481ef9608",
         "account_number": "13048322",
         "branch_code": "123456",
-        "bank_name": "National Australia Bank",
+        "bank_name": "Bank of New Zealand",
         "state": "pending_verification",
         "iav_provider": null,
         "iav_status": null,
@@ -11408,7 +11408,7 @@ Use this endpoint to resend a failed webhook delivery.
       "id": "55afddde-4296-4daf-8e49-7ba481ef9608",
       "account_number": "13048322",
       "branch_code": "123456",
-      "bank_name": "National Australia Bank",
+      "bank_name": "Bank of New Zealand",
       "state": "active",
       "iav_provider": null,
       "iav_status": null,
@@ -11489,7 +11489,7 @@ Use this endpoint to resend a failed webhook delivery.
       "id": "fcabeacb-2ef6-4b27-ba19-4f6fa0d57dcb",
       "account_number": "947434694",
       "branch_code": "304304",
-      "bank_name": "National Australia Bank",
+      "bank_name": "Bank of New Zealand",
       "state": "active",
       "iav_provider": null,
       "iav_status": null,

--- a/source/openapi3/split.yaml
+++ b/source/openapi3/split.yaml
@@ -1192,7 +1192,7 @@ info:
     ```
 
     Split-Signature:
-    1514772000.93eee90206280b25e82b38001e23961cba4c007f4d925ba71ecc2d9804978635
+    1514772000.93eee90206280b25e82b38001e23961ASB4c007f4d925ba71ecc2d9804978635
 
     ```
 
@@ -3940,8 +3940,8 @@ components:
             removed_at:
             failure_reason:
             institution:
-              short_name: CBA
-              full_name: Commonwealth Bank of Australia
+              short_name: ASB
+              full_name: Auckland Savings Bank
             contact:
               id: 626e15b1-aa4a-496e-b5d6-3f8c1a6d2189
               name: George Morissette
@@ -3955,8 +3955,8 @@ components:
             removed_at:
             failure_reason:
             institution:
-              short_name: CBA
-              full_name: Commonwealth Bank of Australia
+              short_name: ASB
+              full_name: Auckland Savings Bank
             contact:
               id: 72e37667-6364-440f-b1bd-56df5654e258
               name: Joel Boyle
@@ -4460,8 +4460,8 @@ components:
           removed_at:
           failure_reason:
           institution:
-            short_name: CBA
-            full_name: Commonwealth Bank of Australia
+            short_name: ASB
+            full_name: Auckland Savings Bank
           contact:
             id: 72e37667-6364-440f-b1bd-56df5654e258
             name: Joel Boyle

--- a/source/openapi3/split.yaml
+++ b/source/openapi3/split.yaml
@@ -3899,7 +3899,7 @@ components:
             bank_name: Bank of New Zealand
             account_number: '3993013'
             status: active
-            title: 'AU.493192.3993013'
+            title: NZ.493192.3993013'
             available_balance: null
           - id: 56df206a-aaff-471a-b075-11882bc8906a
             branch_code: '302193'

--- a/source/openapi3/split.yaml
+++ b/source/openapi3/split.yaml
@@ -5868,7 +5868,6 @@ components:
             phone: 0418495033
             street_address: 98 Acme Avenue
             suburb: Lead
-            state: NSW
             postcode: '2478'
     SimulateIncomingPayIDPaymentRequest:
       required:

--- a/source/openapi3/split.yaml
+++ b/source/openapi3/split.yaml
@@ -2530,7 +2530,7 @@ paths:
           style: form
           schema:
             type: string
-          example: 068231
+          example: 020018
         - name: bank_account_account_number
           in: query
           description: 'Single value, exact match'
@@ -3895,14 +3895,14 @@ components:
       example:
         data:
           - id: 6a7ed958-f1e8-42dc-8c02-3901d7057357
-            branch_code: '493192'
+            branch_code: '020100'
             bank_name: Bank of New Zealand
             account_number: '3993013'
             status: active
-            title: NZ.493192.3993013'
+            title: NZ.020100.3993013'
             available_balance: null
           - id: 56df206a-aaff-471a-b075-11882bc8906a
-            branch_code: '302193'
+            branch_code: '020120'
             bank_name: Bank of New Zealand
             account_number: '119302'
             status: active
@@ -4321,7 +4321,7 @@ components:
             bank_account:
               id: 095c5ab7-7fa8-40fd-b317-cddbbf4c8fbc
               account_number: '494307'
-              branch_code: '435434'
+              branch_code: '020040'
               bank_name: Bank of New Zealand
               state: active
               iav_provider: split
@@ -4338,7 +4338,7 @@ components:
             bank_account:
               id: 861ff8e4-7acf-4897-9e53-e7c5ae5f7cc0
               account_number: '4395959'
-              branch_code: 068231
+              branch_code: 020018
               bank_name: Bank of New Zealand
               state: active
               iav_provider: split
@@ -4372,7 +4372,7 @@ components:
             bank_account:
               id: 55afddde-4296-4daf-8e49-7ba481ef9608
               account_number: '13048322'
-              branch_code: '123456'
+              branch_code: '020136'
               bank_name: Bank of New Zealand
               state: pending_verification
               iav_provider: null
@@ -4408,7 +4408,7 @@ components:
       example:
         name: Hunter Thompson
         email: hunter@batcountry.com
-        branch_code: '123456'
+        branch_code: '020136'
         account_number: '13048322'
         metadata:
           custom_key: Custom string
@@ -4433,7 +4433,7 @@ components:
           bank_account:
             id: 55afddde-4296-4daf-8e49-7ba481ef9608
             account_number: '13048322'
-            branch_code: '123456'
+            branch_code: '020136'
             bank_name: Bank of New Zealand
             state: active
             iav_provider: null
@@ -4619,7 +4619,7 @@ components:
           bank_account:
             id: fcabeacb-2ef6-4b27-ba19-4f6fa0d57dcb
             account_number: '947434694'
-            branch_code: '304304'
+            branch_code: '020159'
             bank_name: Bank of New Zealand
             state: active
             iav_provider: null

--- a/source/openapi3/split.yaml
+++ b/source/openapi3/split.yaml
@@ -51,7 +51,7 @@ info:
     * Dates & times are returned in UTC using [ISO
     8601](https://en.wikipedia.org/wiki/ISO_8601) format with second accuracy.
     With requests, when no TZ is supplied, the configured TZ of the
-    authenticated user is used, or `Australia/Sydney` if no TZ is configured.
+    authenticated user is used, or `Pacific/Auckland` if no TZ is configured.
 
     * Amounts are always in cents with no decimals unless otherwise stated.
 
@@ -3896,14 +3896,14 @@ components:
         data:
           - id: 6a7ed958-f1e8-42dc-8c02-3901d7057357
             branch_code: '493192'
-            bank_name: National Australia Bank
+            bank_name: Bank of New Zealand
             account_number: '3993013'
             status: active
             title: 'AU.493192.3993013'
             available_balance: null
           - id: 56df206a-aaff-471a-b075-11882bc8906a
             branch_code: '302193'
-            bank_name: National Australia Bank
+            bank_name: Bank of New Zealand
             account_number: '119302'
             status: active
             title: 'Trust Account'
@@ -4322,7 +4322,7 @@ components:
               id: 095c5ab7-7fa8-40fd-b317-cddbbf4c8fbc
               account_number: '494307'
               branch_code: '435434'
-              bank_name: National Australia Bank
+              bank_name: Bank of New Zealand
               state: active
               iav_provider: split
               iav_status: active
@@ -4339,7 +4339,7 @@ components:
               id: 861ff8e4-7acf-4897-9e53-e7c5ae5f7cc0
               account_number: '4395959'
               branch_code: 068231
-              bank_name: National Australia Bank
+              bank_name: Bank of New Zealand
               state: active
               iav_provider: split
               iav_status: credentials_invalid
@@ -4373,7 +4373,7 @@ components:
               id: 55afddde-4296-4daf-8e49-7ba481ef9608
               account_number: '13048322'
               branch_code: '123456'
-              bank_name: National Australia Bank
+              bank_name: Bank of New Zealand
               state: pending_verification
               iav_provider: null
               iav_status: null
@@ -4434,7 +4434,7 @@ components:
             id: 55afddde-4296-4daf-8e49-7ba481ef9608
             account_number: '13048322'
             branch_code: '123456'
-            bank_name: National Australia Bank
+            bank_name: Bank of New Zealand
             state: active
             iav_provider: null
             iav_status: null
@@ -4620,7 +4620,7 @@ components:
             id: fcabeacb-2ef6-4b27-ba19-4f6fa0d57dcb
             account_number: '947434694'
             branch_code: '304304'
-            bank_name: National Australia Bank
+            bank_name: Bank of New Zealand
             state: active
             iav_provider: null
             iav_status: null

--- a/source/openapi3/split.yaml
+++ b/source/openapi3/split.yaml
@@ -706,8 +706,6 @@ info:
 
     | `suburb` | |
 
-    | `state` | See the sign up page for accepted values |
-
     | `postcode` | |
 
     | `first_name` | |
@@ -1192,7 +1190,7 @@ info:
     ```
 
     Split-Signature:
-    1514772000.93eee90206280b25e82b38001e23961ASB4c007f4d925ba71ecc2d9804978635
+    1514772000.93eee90206280b25e82b38001e23961cba4c007f4d925ba71ecc2d9804978635
 
     ```
 


### PR DESCRIPTION
## 👀 Reviewers

## 💡 Why
* [ZEP-1768](https://zeptoau.atlassian.net/browse/ZEP-1768)

## 📝 What

1. Change instances of Australian banks to NZ counterpart
   1. NAB -> BNZ (Bank of New Zealand)
   2. CBA -> ASB (Auckland Savings Bank)
2. Removed State: NSW address line from example responses