### PR TITLE
ZEP-1765 Remove status page links from NZ docs

### DIFF
--- a/source/openapi3/split.yaml
+++ b/source/openapi3/split.yaml
@@ -59,14 +59,6 @@ info:
         * Sandbox IP: `13.237.142.60`
         * Production IPs: `52.64.11.67` and `13.238.78.114`
 
-
-    <div class="middle-header">System Status</div>
-
-
-    Check the platform status, or subscribe to receive notifications at [status.split.cash](https://status.split.cash/).
-    If you would like to check platform status programmatically, please refer to [status.split.cash/api](https://status.split.cash/api).
-
-
     <div class="middle-header">Breaking Changes</div>
 
 


### PR DESCRIPTION
Removing System Status section from the docs. This is due to the links within the section referencing the AU system status pages. This section will be re-added at a later stage with the NZ system status page links and associated text.

Before:

![Screen Shot 2022-04-21 at 2 28 43 pm](https://user-images.githubusercontent.com/70265678/164372716-1fa033cc-d2ee-4c15-82a6-11da923cdfd4.png)

After (System Status section removed):

![Screen Shot 2022-04-21 at 2 29 02 pm](https://user-images.githubusercontent.com/70265678/164372764-c728868d-90bf-43d6-b7e5-c8516e2dd7b7.png)

