### PR TITLE
ZEP-1785: Remove reference to NPP

### DIFF
--- a/source/index.html.md
+++ b/source/index.html.md
@@ -5098,7 +5098,7 @@ curl --request POST \
   --header 'accept: application/json' \
   --header 'authorization: Bearer {access-token}' \
   --header 'content-type: application/json' \
-  --data '{"amount":500,"channels":["direct_entry"],"reason":"Because reason","your_bank_account_id":"9c70871d-8e36-4c3e-8a9c-c0ee20e7c679","metadata":{"custom_key":"Custom string","another_custom_key":"Maybe a URL"}}'
+  --data '{"amount":500,"reason":"Because reason","your_bank_account_id":"9c70871d-8e36-4c3e-8a9c-c0ee20e7c679","metadata":{"custom_key":"Custom string","another_custom_key":"Maybe a URL"}}'
 ```
 
 ```ruby
@@ -5115,7 +5115,7 @@ request = Net::HTTP::Post.new(url)
 request["content-type"] = 'application/json'
 request["accept"] = 'application/json'
 request["authorization"] = 'Bearer {access-token}'
-request.body = "{\"amount\":500,\"channels\":[\"direct_entry\"],\"reason\":\"Because reason\",\"your_bank_account_id\":\"9c70871d-8e36-4c3e-8a9c-c0ee20e7c679\",\"metadata\":{\"custom_key\":\"Custom string\",\"another_custom_key\":\"Maybe a URL\"}}"
+request.body = "{\"amount\":500,\"reason\":\"Because reason\",\"your_bank_account_id\":\"9c70871d-8e36-4c3e-8a9c-c0ee20e7c679\",\"metadata\":{\"custom_key\":\"Custom string\",\"another_custom_key\":\"Maybe a URL\"}}"
 
 response = http.request(request)
 puts response.read_body
@@ -5150,7 +5150,6 @@ var req = http.request(options, function (res) {
 });
 
 req.write(JSON.stringify({ amount: 500,
-  channels: [ 'direct_entry' ],
   reason: 'Because reason',
   your_bank_account_id: '9c70871d-8e36-4c3e-8a9c-c0ee20e7c679',
   metadata:
@@ -5164,7 +5163,7 @@ import http.client
 
 conn = http.client.HTTPSConnection("nz.api.sandbox.zepto.money")
 
-payload = "{\"amount\":500,\"channels\":[\"direct_entry\"],\"reason\":\"Because reason\",\"your_bank_account_id\":\"9c70871d-8e36-4c3e-8a9c-c0ee20e7c679\",\"metadata\":{\"custom_key\":\"Custom string\",\"another_custom_key\":\"Maybe a URL\"}}"
+payload = "{\"amount\":500,\"reason\":\"Because reason\",\"your_bank_account_id\":\"9c70871d-8e36-4c3e-8a9c-c0ee20e7c679\",\"metadata\":{\"custom_key\":\"Custom string\",\"another_custom_key\":\"Maybe a URL\"}}"
 
 headers = {
     'content-type': "application/json",
@@ -5185,7 +5184,7 @@ HttpResponse<String> response = Unirest.post("https://nz.api.sandbox.zepto.money
   .header("content-type", "application/json")
   .header("accept", "application/json")
   .header("authorization", "Bearer {access-token}")
-  .body("{\"amount\":500,\"channels\":[\"direct_entry\"],\"reason\":\"Because reason\",\"your_bank_account_id\":\"9c70871d-8e36-4c3e-8a9c-c0ee20e7c679\",\"metadata\":{\"custom_key\":\"Custom string\",\"another_custom_key\":\"Maybe a URL\"}}")
+  .body("{\"amount\":500,\"reason\":\"Because reason\",\"your_bank_account_id\":\"9c70871d-8e36-4c3e-8a9c-c0ee20e7c679\",\"metadata\":{\"custom_key\":\"Custom string\",\"another_custom_key\":\"Maybe a URL\"}}")
   .asString();
 ```
 
@@ -5196,7 +5195,7 @@ $client = new http\Client;
 $request = new http\Client\Request;
 
 $body = new http\Message\Body;
-$body->append('{"amount":500,"channels":["direct_entry"],"reason":"Because reason","your_bank_account_id":"9c70871d-8e36-4c3e-8a9c-c0ee20e7c679","metadata":{"custom_key":"Custom string","another_custom_key":"Maybe a URL"}}');
+$body->append('{"amount":500,"reason":"Because reason","your_bank_account_id":"9c70871d-8e36-4c3e-8a9c-c0ee20e7c679","metadata":{"custom_key":"Custom string","another_custom_key":"Maybe a URL"}}');
 
 $request->setRequestUrl('https://nz.api.sandbox.zepto.money/credits/string/refunds');
 $request->setRequestMethod('POST');
@@ -5228,7 +5227,7 @@ func main() {
 
 	url := "https://nz.api.sandbox.zepto.money/credits/string/refunds"
 
-	payload := strings.NewReader("{\"amount\":500,\"channels\":[\"direct_entry\"],\"reason\":\"Because reason\",\"your_bank_account_id\":\"9c70871d-8e36-4c3e-8a9c-c0ee20e7c679\",\"metadata\":{\"custom_key\":\"Custom string\",\"another_custom_key\":\"Maybe a URL\"}}")
+	payload := strings.NewReader("{\"amount\":500,\"reason\":\"Because reason\",\"your_bank_account_id\":\"9c70871d-8e36-4c3e-8a9c-c0ee20e7c679\",\"metadata\":{\"custom_key\":\"Custom string\",\"another_custom_key\":\"Maybe a URL\"}}")
 
 	req, _ := http.NewRequest("POST", url, payload)
 
@@ -5261,9 +5260,6 @@ Certain rules apply to the issuance of a refund:
 ```json
 {
   "amount": 500,
-  "channels": [
-    "direct_entry"
-  ],
   "reason": "Because reason",
   "your_bank_account_id": "9c70871d-8e36-4c3e-8a9c-c0ee20e7c679",
   "metadata": {
@@ -5280,7 +5276,6 @@ Certain rules apply to the issuance of a refund:
 |credit_ref|path|string|true|The credit reference number e.g C.625v|
 |body|body|[IssueARefundRequest](#schemaissuearefundrequest)|true|No description|
 |» amount|body|integer|true|Amount in cents refund (Min: 1 - Max: 99999999999)|
-|» channels|body|array|false|Specify the payment channel to be used, in order. (direct_entry)|
 |» reason|body|string|false|Reason for the refund. First 9 characters are visible to both parties.|
 |» your_bank_account_id|body|string(uuid)|false|Specify where we should take the funds for this transaction. If omitted, your primary bank account will be used.|
 |» metadata|body|[Metadata](#schemametadata)|false|Use for your custom data and certain Zepto customisations.|
@@ -5298,9 +5293,6 @@ Certain rules apply to the issuance of a refund:
     "your_bank_account_id": "9c70871d-8e36-4c3e-8a9c-c0ee20e7c679",
     "created_at": "2021-06-01T07:20:24Z",
     "amount": 500,
-    "channels": [
-      "direct_entry"
-    ],
     "reason": "Subscription refund",
     "contacts": {
       "source_contact_id": "194b0237-6c2c-4705-b4fb-308274b14eda",
@@ -5720,8 +5712,6 @@ A transaction (debit or credit) can have the following statuses:
       "description": null,
       "amount": 1,
       "bank_account_id": "56df206a-aaff-471a-b075-11882bc8906a"
-      "channels": ["float_account"]
-      "current_channel": "float_account"
     }
   ]
 }
@@ -5788,8 +5778,6 @@ The rejected, returned, voided & prefailed statuses are always accompanied by a 
       "description": null,
       "amount": 1,
       "bank_account_id": "56df206a-aaff-471a-b075-11882bc8906a"
-      "channels": ["float_account"]
-      "current_channel": "float_account"
     }
   ]
 }
@@ -9138,9 +9126,6 @@ Use this endpoint to resend a failed webhook delivery.
 ```json
 {
   "amount": 500,
-  "channels": [
-    "direct_entry"
-  ],
   "reason": "Because reason",
   "your_bank_account_id": "9c70871d-8e36-4c3e-8a9c-c0ee20e7c679",
   "metadata": {
@@ -9157,7 +9142,6 @@ Use this endpoint to resend a failed webhook delivery.
 |Name|Type|Required|Description|
 |---|---|---|---|
 |amount|integer|true|Amount in cents refund (Min: 1 - Max: 99999999999)|
-|channels|array|false|Specify the payment channel to be used, in order. (direct_entry)|
 |reason|string|false|Reason for the refund. First 9 characters are visible to both parties.|
 |your_bank_account_id|string(uuid)|false|Specify where we should take the funds for this transaction. If omitted, your primary bank account will be used.|
 |metadata|[Metadata](#schemametadata)|false|No description|
@@ -9175,9 +9159,6 @@ Use this endpoint to resend a failed webhook delivery.
     "your_bank_account_id": "9c70871d-8e36-4c3e-8a9c-c0ee20e7c679",
     "created_at": "2021-06-01T07:20:24Z",
     "amount": 500,
-    "channels": [
-      "direct_entry"
-    ],
     "reason": "Subscription refund",
     "contacts": {
       "source_contact_id": "194b0237-6c2c-4705-b4fb-308274b14eda",
@@ -9621,32 +9602,6 @@ Use this endpoint to resend a failed webhook delivery.
 |from_account_number|string|false|Default: "12345678"|
 |debtor_name|string|false|Default:  "Simulated Debtor"|
 |debtor_legal_name|string|false|Default:  "Simulated Debtor Pty Ltd"|
-
-## SimulateIncomingNPPBBANPaymentRequest
-
-<a id="schemasimulateincomingnppbbanpaymentrequest"></a>
-
-```json
-{
-  "to_bsb": "802919",
-  "to_account_number": "88888888",
-  "amount": 10000
-}
-```
-
-### Properties
-
-|Name|Type|Required|Description|
-|---|---|---|---|
-|to_bsb|string|true|Zepto float account BSB (usually 802919)|
-|to_account_number|string|true|Zepto float account number|
-|amount|integer|true|Amount in cents (Min: 1 - Max: 99999999999)|
-|payment_description|string|false|Default: "Simulated NPP payment"|
-|payment_reference|string|false|Default: "simulated-npp-payment"|
-|from_bsb|string|false|Default: "014209"|
-|from_account_number|string|false|Default: "12345678"|
-|debtor_name|string|false|Default: "Simulated Debtor"|
-|debtor_legal_name|string|false|Default: "Simulated Debtor Pty Ltd"|
 
 ## SimulateIncomingDEPaymentRequest
 

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -483,9 +483,9 @@ You can also pass the values directly to the sign up page outside of the OAuth2 
 ```json
 {
   "failure": {
-      "code": "E302",
-      "title": "BSB Not NPP Enabled",
-      "detail": "The target BSB is not NPP enabled. Please try another channel."
+      "code": "E105",
+      "title": "Account Not Found",
+      "detail": "The target account number is incorrect."
   }
 }
 ```
@@ -559,29 +559,6 @@ To simulate [transaction failures](#failure-reasons) create a Payment or Payment
   3. Request payment from a contact with a closed bank account:
     * Initiate a Payment Request for <code>$0.02</code>.
     * Zepto will mimic a failure to debit the contact's bank account.
-
-## NPP Payment failures
-### [NEW] Using failure codes
-<aside class="notice">
-  <ul>
-      <li><a href="#npp-credit-failures">NPP credit failure codes</a></li>
-  </ul>
-</aside>
-To simulate a transaction failure, create a Payment with an amount corresponding to the desired [failure code](#npp-credit-failures).
-For example:
-
-* NPP amount `$3.02` will cause the transaction to fail, triggering credit failure code `E302` (BSB Not NPP Enabled).
-* NPP amount `$3.04` will cause the transaction to fail, triggering credit failure code `E304` (Account Not Found).
-
-### [DEPRECATED] Using failure reasons
-If you are utilising an [Account Float](https://help.split.cash/en/articles/4275280-utilising-an-account-float) to create NPP payments, you can simulate a transaction that fails to process through the NPP channel by [creating a Payment from your account float](https://help.split.cash/en/articles/4275293-transacting-from-your-account-float) for one of the following amounts.
-
-| Transaction failure reason | Failure details | Amount |
-|----------------------------|-----------------|---------|
-| `refer_to_split`           | Real-time payment service currently unavailable |  $1.55  |
-| `refer_to_customer`        | Real-time payment rejected by recipient |  $1.60  |
-| `refer_to_customer`        | Real-time payments not available for recipient |  $1.65  |
-You will receive all the same notifications as if this happened in our live environment. We recommend you check out our article on [what happens when an NPP Payment fails](https://help.split.cash/en/articles/4405560-what-happens-when-an-npp-payment-fails) to learn more about what happens when an NPP Payment is unable to process.
 
 ## Instant account verification accounts
 When using any of our hosted solutions ([Payment Requests](https://help.split.cash/payment-requests/open-payment-requests), [Open Agreements](https://help.split.cash/agreements/open-agreement) or [Unassigned Agreements](http://help.split.cash/agreements/unassigned-agreement)) you may want to test the [Instant Account Verification (IAV)](http://help.split.cash/bank-accounts/instant-account-verification-iav) process where we accept online banking credentials to validate bank account access. To do so, you can use the following credentials:
@@ -4665,7 +4642,7 @@ func main() {
 |» payouts|body|[[Payout](#schemapayout)]|true|One Payout object only|
 |»» Payout|body|[Payout](#schemapayout)|false|The actual Payout|
 |»»» amount|body|integer|true|Amount in cents to pay the recipient|
-|»»» description|body|string|true|Description that both the payer and recipient can see. For Direct Entry payments, the payout recipient will see the first 9 characters of this description. For NPP payments, the payout recipient will see the first 280 characters of this description.|
+|»»» description|body|string|true|Description that both the payer and recipient can see. For Direct Entry payments, the payout recipient will see the first 9 characters of this description.|
 |»»» recipient_contact_id|body|string|true|Contact to pay (`Contact.data.id`)|
 |»»» metadata|body|Metadata|false|Use for your custom data and certain Zepto customisations. Stored against generated transactions and included in associated webhook payloads.|
 |»» metadata|body|[Metadata](#schemametadata)|false|Use for your custom data and certain Zepto customisations.|
@@ -5105,7 +5082,7 @@ Get a single payment by its reference
 Refunds can be issued for any successfully completed Payment Request transaction. This includes:
 
 1. Payment Requests for direct debit payments **(Collections)**:
-2. Payment Requests for funds received via DE/NPP **(Receivables)**:
+2. Payment Requests for funds received via DE **(Receivables)**:
 
 This allows you to return any funds that were previously collected or received into one of your bank/float accounts.
 
@@ -5303,7 +5280,7 @@ Certain rules apply to the issuance of a refund:
 |credit_ref|path|string|true|The credit reference number e.g C.625v|
 |body|body|[IssueARefundRequest](#schemaissuearefundrequest)|true|No description|
 |» amount|body|integer|true|Amount in cents refund (Min: 1 - Max: 99999999999)|
-|» channels|body|array|false|Specify the payment channel to be used, in order. (new_payments_platform, direct_entry, or both)|
+|» channels|body|array|false|Specify the payment channel to be used, in order. (direct_entry)|
 |» reason|body|string|false|Reason for the refund. First 9 characters are visible to both parties.|
 |» your_bank_account_id|body|string(uuid)|false|Specify where we should take the funds for this transaction. If omitted, your primary bank account will be used.|
 |» metadata|body|[Metadata](#schemametadata)|false|Use for your custom data and certain Zepto customisations.|
@@ -5784,18 +5761,6 @@ The rejected, returned, voided & prefailed statuses are always accompanied by a 
 | E252 | Insufficient Funds | There were insufficient funds to complete the transaction. |
 | E253 | System Error | The transaction was unable to complete. Please contact Zepto for assistance. |
 | E299 | Unknown DE Error | An unknown DE error occurred. Please contact Zepto for assistance. |
-### NPP credit failures
-| Code | Title | Detail |
-| ------------ | ------------- | -------------- |
-| E301 | Upstream Network Outage | An upstream network issue occurred. Please try again later. |
-| E302 | BSB Not NPP Enabled | The target BSB is not NPP enabled. Please try another channel. |
-| E303 | Account Not NPP Enabled | The target account exists but cannot accept funds via the NPP. Please try another channel. |
-| E304 | Account Not Found | The target account number cannot be found. |
-| E305 | Intermittent Outage At Target Institution | The target financial institution is experiencing technical difficulties. Please try again later. |
-| E306 | Account Closed | The target account is closed. |
-| E307 | Target Institution Offline | The target financial institution is undergoing maintenance or experiencing an outage. Please try again later. |
-| E308 | Account Blocked | The target account is blocked and cannot receive funds. |
-| E399 | Unknown NPP Error | An unknown NPP error occurred. Please contact Zepto for assistance. |
 
 ## [DEPRECATED] Failure reasons
 
@@ -6110,7 +6075,6 @@ func main() {
       "amount": 19999,
       "bank_account_id": "c2e329ae-606f-4311-a9ab-a751baa1915c",
       "channels": [
-        "new_payments_platform",
         "direct_entry"
       ],
       "current_channel": "direct_entry",
@@ -8700,7 +8664,7 @@ Use this endpoint to resend a failed webhook delivery.
 |Name|Type|Required|Description|
 |---|---|---|---|
 |amount|integer|true|Amount in cents to pay the recipient|
-|description|string|true|Description that both the payer and recipient can see. For Direct Entry payments, the payout recipient will see the first 9 characters of this description. For NPP payments, the payout recipient will see the first 280 characters of this description.|
+|description|string|true|Description that both the payer and recipient can see. For Direct Entry payments, the payout recipient will see the first 9 characters of this description.|
 |recipient_contact_id|string|true|Contact to pay (`Contact.data.id`)|
 |metadata|Metadata|false|Use for your custom data and certain Zepto customisations. Stored against generated transactions and included in associated webhook payloads.|
 
@@ -9193,7 +9157,7 @@ Use this endpoint to resend a failed webhook delivery.
 |Name|Type|Required|Description|
 |---|---|---|---|
 |amount|integer|true|Amount in cents refund (Min: 1 - Max: 99999999999)|
-|channels|array|false|Specify the payment channel to be used, in order. (new_payments_platform, direct_entry, or both)|
+|channels|array|false|Specify the payment channel to be used, in order. (direct_entry)|
 |reason|string|false|Reason for the refund. First 9 characters are visible to both parties.|
 |your_bank_account_id|string(uuid)|false|Specify where we should take the funds for this transaction. If omitted, your primary bank account will be used.|
 |metadata|[Metadata](#schemametadata)|false|No description|
@@ -9240,7 +9204,7 @@ Use this endpoint to resend a failed webhook delivery.
 |» your_bank_account_id|string|true|The source bank/float account (UUID)|
 |» created_at|string(date-time)|true|The date-time when the Payment Request was created|
 |» amount|integer|true|The amount value provided (Min: 1 - Max: 99999999999)|
-|» channels|array|false|The requested payment channel(s) to be used, in order. (new_payments_platform, direct_entry, or both)|
+|» channels|array|false|The requested payment channel(s) to be used, in order. (direct_entry)|
 |» reason|string|true|Reason for the refund|
 
 ## ListOutgoingRefundsResponse
@@ -9412,7 +9376,6 @@ Use this endpoint to resend a failed webhook delivery.
       "amount": 19999,
       "bank_account_id": "c2e329ae-606f-4311-a9ab-a751baa1915c",
       "channels": [
-        "new_payments_platform",
         "direct_entry"
       ],
       "current_channel": "direct_entry",

--- a/source/openapi3/split.yaml
+++ b/source/openapi3/split.yaml
@@ -1820,8 +1820,6 @@ tags:
             "description": null,
             "amount": 1,
             "bank_account_id": "56df206a-aaff-471a-b075-11882bc8906a"
-            "channels": ["float_account"]
-            "current_channel": "float_account"
           }
         ]
       }
@@ -1928,8 +1926,6 @@ tags:
             "description": null,
             "amount": 1,
             "bank_account_id": "56df206a-aaff-471a-b075-11882bc8906a"
-            "channels": ["float_account"]
-            "current_channel": "float_account"
           }
         ]
       }
@@ -4556,9 +4552,6 @@ components:
           max: 99999999999
           description: 'Amount in cents refund (Min: 1 - Max: 99999999999)'
           example: 500
-        channels:
-          description: Specify the payment channel to be used, in order. (direct_entry)
-          type: array
         reason:
           type: string
           description: Reason for the refund. First 9 characters are visible to both parties.
@@ -4571,7 +4564,6 @@ components:
           $ref: '#/components/schemas/Metadata'
       example:
         amount: 500
-        channels: ["direct_entry"]
         reason: Because reason
         your_bank_account_id: 9c70871d-8e36-4c3e-8a9c-c0ee20e7c679
         metadata:
@@ -4629,7 +4621,6 @@ components:
           your_bank_account_id: 9c70871d-8e36-4c3e-8a9c-c0ee20e7c679
           created_at: '2021-06-01T07:20:24Z'
           amount: 500
-          channels: ["direct_entry"]
           reason: Subscription refund
           contacts:
             source_contact_id: 194b0237-6c2c-4705-b4fb-308274b14eda
@@ -4978,56 +4969,6 @@ components:
           description: 'Default:  "Simulated Debtor Pty Ltd"'
       example:
         payid_email: incoming@split.cash
-        amount: 10000
-    SimulateIncomingNPPBBANPaymentRequest:
-      required:
-        - to_bsb
-        - to_account_number
-        - amount
-      type: object
-      properties:
-        to_bsb:
-          type: string
-          min: 6
-          max: 6
-          description: 'Zepto float account BSB (usually 802919)'
-        to_account_number:
-          type: string
-          min: 1
-          max: 9
-          description: 'Zepto float account number'
-        amount:
-          type: integer
-          min: 1
-          max: 99999999999
-          description: 'Amount in cents (Min: 1 - Max: 99999999999)'
-        payment_description:
-          type: string
-          description: 'Default: "Simulated NPP payment"'
-        payment_reference:
-          type: string
-          description: 'Default: "simulated-npp-payment"'
-        from_bsb:
-          type: string
-          min: 6
-          max: 6
-          description: 'Default: "014209"'
-        from_account_number:
-          type: string
-          min: 1
-          max: 9
-          description: 'Default: "12345678"'
-        debtor_name:
-          type: string
-          min: 1
-          description: 'Default: "Simulated Debtor"'
-        debtor_legal_name:
-          type: string
-          min: 1
-          description: 'Default: "Simulated Debtor Pty Ltd"'
-      example:
-        to_bsb: "802919"
-        to_account_number: "88888888"
         amount: 10000
     SimulateIncomingDEPaymentRequest:
       required:

--- a/source/openapi3/split.yaml
+++ b/source/openapi3/split.yaml
@@ -737,9 +737,9 @@ info:
 
     {
       "failure": {
-          "code": "E302",
-          "title": "BSB Not NPP Enabled",
-          "detail": "The target BSB is not NPP enabled. Please try another channel."
+          "code": "E105",
+          "title": "Account Not Found",
+          "detail": "The target account number is incorrect."
       }
     }
 
@@ -847,48 +847,6 @@ info:
       3. Request payment from a contact with a closed bank account:
         * Initiate a Payment Request for <code>$0.02</code>.
         * Zepto will mimic a failure to debit the contact's bank account.
-
-    ## NPP Payment failures
-
-    ### [NEW] Using failure codes
-
-    <aside class="notice">
-      <ul>
-          <li><a href="#npp-credit-failures">NPP credit failure codes</a></li>
-      </ul>
-    </aside>
-
-    To simulate a transaction failure, create a Payment with an amount corresponding to the desired [failure code](#npp-credit-failures).
-
-    For example:
-
-
-    * NPP amount `$3.02` will cause the transaction to fail, triggering credit failure code `E302` (BSB Not NPP Enabled).
-
-    * NPP amount `$3.04` will cause the transaction to fail, triggering credit failure code `E304` (Account Not Found).
-
-
-    ### [DEPRECATED] Using failure reasons
-
-    If you are utilising an [Account Float](https://help.split.cash/en/articles/4275280-utilising-an-account-float)
-    to create NPP payments, you can simulate a transaction that fails to process through the NPP channel by
-    [creating a Payment from your account float](https://help.split.cash/en/articles/4275293-transacting-from-your-account-float)
-    for one of the following amounts.
-
-
-    | Transaction failure reason | Failure details | Amount |
-
-    |----------------------------|-----------------|---------|
-
-    | `refer_to_split`           | Real-time payment service currently unavailable |  $1.55  |
-
-    | `refer_to_customer`        | Real-time payment rejected by recipient |  $1.60  |
-
-    | `refer_to_customer`        | Real-time payments not available for recipient |  $1.65  |
-
-    You will receive all the same notifications as if this happened in our live environment. We recommend you
-    check out our article on [what happens when an NPP Payment fails](https://help.split.cash/en/articles/4405560-what-happens-when-an-npp-payment-fails)
-    to learn more about what happens when an NPP Payment is unable to process.
 
 
     ## Instant account verification accounts
@@ -1771,7 +1729,7 @@ tags:
 
       1. Payment Requests for direct debit payments **(Collections)**:
 
-      2. Payment Requests for funds received via DE/NPP **(Receivables)**:
+      2. Payment Requests for funds received via DE **(Receivables)**:
 
 
       This allows you to return any funds that were previously collected or received into one of your bank/float accounts.
@@ -1939,30 +1897,6 @@ tags:
       | E253 | System Error | The transaction was unable to complete. Please contact Zepto for assistance. |
 
       | E299 | Unknown DE Error | An unknown DE error occurred. Please contact Zepto for assistance. |
-
-      ### NPP credit failures
-
-      | Code | Title | Detail |
-
-      | ------------ | ------------- | -------------- |
-
-      | E301 | Upstream Network Outage | An upstream network issue occurred. Please try again later. |
-
-      | E302 | BSB Not NPP Enabled | The target BSB is not NPP enabled. Please try another channel. |
-
-      | E303 | Account Not NPP Enabled | The target account exists but cannot accept funds via the NPP. Please try another channel. |
-
-      | E304 | Account Not Found | The target account number cannot be found. |
-
-      | E305 | Intermittent Outage At Target Institution | The target financial institution is experiencing technical difficulties. Please try again later. |
-
-      | E306 | Account Closed | The target account is closed. |
-
-      | E307 | Target Institution Offline | The target financial institution is undergoing maintenance or experiencing an outage. Please try again later. |
-
-      | E308 | Account Blocked | The target account is blocked and cannot receive funds. |
-
-      | E399 | Unknown NPP Error | An unknown NPP error occurred. Please contact Zepto for assistance. |
 
 
       ## [DEPRECATED] Failure reasons
@@ -4039,7 +3973,7 @@ components:
           example: 30000
         description:
           type: string
-          description: Description that both the payer and recipient can see. For Direct Entry payments, the payout recipient will see the first 9 characters of this description. For NPP payments, the payout recipient will see the first 280 characters of this description.
+          description: Description that both the payer and recipient can see. For Direct Entry payments, the payout recipient will see the first 9 characters of this description.
           example: A tandem skydive jump SB23094
         recipient_contact_id:
           type: string
@@ -4623,7 +4557,7 @@ components:
           description: 'Amount in cents refund (Min: 1 - Max: 99999999999)'
           example: 500
         channels:
-          description: Specify the payment channel to be used, in order. (new_payments_platform, direct_entry, or both)
+          description: Specify the payment channel to be used, in order. (direct_entry)
           type: array
         reason:
           type: string
@@ -4683,7 +4617,7 @@ components:
               description: 'The amount value provided (Min: 1 - Max: 99999999999)'
             channels:
               type: array
-              description: The requested payment channel(s) to be used, in order. (new_payments_platform, direct_entry, or both)
+              description: The requested payment channel(s) to be used, in order. (direct_entry)
             reason:
               type: string
               description: Reason for the refund
@@ -4843,7 +4777,7 @@ components:
             description: Online purchase
             amount: 19999
             bank_account_id: 'c2e329ae-606f-4311-a9ab-a751baa1915c'
-            channels: [new_payments_platform,direct_entry]
+            channels: [direct_entry]
             current_channel: direct_entry
             metadata:
               customer_id: xur4492


### PR DESCRIPTION
Removes specific reference to NPP and the its options for other endpoints.

There are still a few references in this PR littered around the place, but they are in endpoints that are being/have been removed entirely.