### PR TITLE
ZEP-1933 Remove '& verify' from getting paid section of NZ Docs

### DIFF
--- a/source/index.html.md
+++ b/source/index.html.md
@@ -344,7 +344,7 @@ Provides the ability to send a Payment Request (get paid) to any Contact that ha
 
 To send a Payment Request to a Contact using the API, you must first have an accepted [Agreement](/#Zepto-API-Agreements) with them.
 
-To do so, you can send them an [Open Agreement link](https://help.split.cash/agreements/open-agreement) or [Unassigned Agreement link](http://help.split.cash/agreements/unassigned-agreement) for them to [elect their bank account](https://help.split.cash/bank-accounts/instant-account-verification-iav) and accept the Agreement.
+To do so, you can send them an [Open Agreement link](https://help.zepto.money/en/articles/6210908-nz-open-agreement) or [Unassigned Agreement link](https://help.zepto.money/en/articles/6210903-nz-unassigned-agreement) for them to accept the Agreement.
 
 Having this in place will allow any future Payment Requests to be automatically approved and processed as per the Agreement terms.
 

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -344,7 +344,7 @@ Provides the ability to send a Payment Request (get paid) to any Contact that ha
 
 To send a Payment Request to a Contact using the API, you must first have an accepted [Agreement](/#Zepto-API-Agreements) with them.
 
-To do so, you can send them an [Open Agreement link](https://help.split.cash/agreements/open-agreement) or [Unassigned Agreement link](http://help.split.cash/agreements/unassigned-agreement) for them to [elect & verify their bank account](https://help.split.cash/bank-accounts/instant-account-verification-iav) and accept the Agreement.
+To do so, you can send them an [Open Agreement link](https://help.split.cash/agreements/open-agreement) or [Unassigned Agreement link](http://help.split.cash/agreements/unassigned-agreement) for them to [elect their bank account](https://help.split.cash/bank-accounts/instant-account-verification-iav) and accept the Agreement.
 
 Having this in place will allow any future Payment Requests to be automatically approved and processed as per the Agreement terms.
 

--- a/source/openapi3/split.yaml
+++ b/source/openapi3/split.yaml
@@ -484,7 +484,7 @@ info:
     [Open Agreement link](https://help.split.cash/agreements/open-agreement) or
     [Unassigned Agreement
     link](http://help.split.cash/agreements/unassigned-agreement) for them to
-    [elect & verify their bank
+    [elect their bank
     account](https://help.split.cash/bank-accounts/instant-account-verification-iav)
     and accept the Agreement.
 

--- a/source/openapi3/split.yaml
+++ b/source/openapi3/split.yaml
@@ -481,12 +481,9 @@ info:
 
 
     To do so, you can send them an
-    [Open Agreement link](https://help.split.cash/agreements/open-agreement) or
+    [Open Agreement link](https://help.zepto.money/en/articles/6210908-nz-open-agreement) or
     [Unassigned Agreement
-    link](http://help.split.cash/agreements/unassigned-agreement) for them to
-    [elect their bank
-    account](https://help.split.cash/bank-accounts/instant-account-verification-iav)
-    and accept the Agreement.
+    link](https://help.zepto.money/en/articles/6210903-nz-unassigned-agreement) for them to accept the Agreement.
 
 
     Having this in place will allow any future Payment


### PR DESCRIPTION
Removing '& verify' from the getting paid section of the NZ docs

Before:

<img width="978" alt="Screen Shot 2022-05-12 at 1 21 28 pm" src="https://user-images.githubusercontent.com/70265678/167985966-04833c95-7705-4d7c-a47f-9ab45157d968.png">

After

<img width="1006" alt="Screen Shot 2022-05-12 at 1 24 37 pm" src="https://user-images.githubusercontent.com/70265678/167985985-289e2916-d8b1-404b-9637-6ec763a38b2d.png">
: