### PR TITLE
ZEP-1936 Remove IAV reference from open agreements section

### DIFF
--- a/source/index.html.md
+++ b/source/index.html.md
@@ -2810,7 +2810,7 @@ You can update the name, email, bank account and metadata of any Contact.
 
 An Open Agreement is essentially an Agreement template with no specific authoriser. Each time an Open Agreement is accepted by either a Zepto account holder or anyone, the authoriser is added to your Contacts list and a new Agreement is automatically created between the Open Agreement initiator and the authoriser.
 
-An Open Agreement can be accepted multiple times by different parties and the result is the same: A new Agreement. Additionally, an Open Agreement can be accepted by anybody, not just other Zepto users. This is achieved by using our [Instant Account Verification process](http://help.split.cash/bank-accounts/instant-account-verification-iav) as part of accepting an [Open Agreement](https://help.split.cash/agreements/open-agreement).
+An Open Agreement can be accepted multiple times by different parties and the result is the same: A new Agreement. Additionally, an Open Agreement can be accepted by anybody, not just other Zepto users.
 ##Lifecycle
 
 An Open Agreement can have the following statuses:

--- a/source/openapi3/split.yaml
+++ b/source/openapi3/split.yaml
@@ -1601,11 +1601,7 @@ tags:
 
       An Open Agreement can be accepted multiple times by different parties and
       the result is the same: A new Agreement. Additionally, an Open Agreement
-      can be accepted by anybody, not just other Zepto users. This is achieved
-      by using our [Instant Account Verification
-      process](http://help.split.cash/bank-accounts/instant-account-verification-iav)
-      as part of accepting an [Open
-      Agreement](https://help.split.cash/agreements/open-agreement).
+      can be accepted by anybody, not just other Zepto users.
 
       ##Lifecycle
 


### PR DESCRIPTION
I removed the sentence referencing IAV from the open agreements section, as IAV will not be launched in NZ.

Before:

<img width="982" alt="Screen Shot 2022-05-12 at 1 40 21 pm" src="https://user-images.githubusercontent.com/70265678/167987479-63ae97bc-27f9-49c6-8f5a-9c1621d1760b.png">

After:

<img width="982" alt="Screen Shot 2022-05-12 at 1 38 54 pm" src="https://user-images.githubusercontent.com/70265678/167987498-0558ee65-74aa-41de-a165-149c39508455.png">

