### PR TITLE
ZEP-1938 Remove information pane from lifecycle section

### DIFF
--- a/source/index.html.md
+++ b/source/index.html.md
@@ -3619,9 +3619,6 @@ A Payment Request (PR) is used to collect funds, via direct debit, from one of y
     1. There is no Agreement in place, then it will not be created.
 
 ##Lifecycle
-
-<aside class="notice">Payment Requests generated from a customer sending you funds will always be <code>approved</code></aside>
-
 A Payment Request can have the following statuses:
 
 | Status | Description |

--- a/source/openapi3/split.yaml
+++ b/source/openapi3/split.yaml
@@ -1696,10 +1696,6 @@ tags:
 
       ##Lifecycle
 
-
-      <aside class="notice">Payment Requests generated from a customer sending you funds will always be <code>approved</code></aside>
-
-
       A Payment Request can have the following statuses:
 
 


### PR DESCRIPTION
Removed the information pane from the Lifecycle heading of Payment Requests section.

Before:

<img width="972" alt="Screen Shot 2022-05-12 at 1 49 56 pm" src="https://user-images.githubusercontent.com/70265678/167988506-3b4d251c-bf35-4bf1-b070-ca261159192d.png">

After:

<img width="975" alt="Screen Shot 2022-05-12 at 1 50 36 pm" src="https://user-images.githubusercontent.com/70265678/167988469-b6c0b0f9-1e97-4f40-8f61-d78fb0810def.png">
: