### PR TITLE
ZEP-1935 Remove old changelogs from changelog section and update github link

### DIFF
--- a/source/index.html.md
+++ b/source/index.html.md
@@ -942,28 +942,9 @@ To protect against timing attacks, use a constant-time string comparison to comp
 # Changelog
 We take backwards compatibility seriously. The following list contains backwards compatible changes:
 
-- **2022-01-21** - Reduced webhook delivery retries on sandbox to a single retry
-- **2021-12-01** - Add ref to Webhook Delivery endpoint
-- **2021-10-08** - Introduced improved transaction failure messaging (code, title and detail)
-- **2021-09-29** - Added/expanded sandbox-only endpoints for simulating incoming payments
-- **2021-09-08** - Added Webhooks and Webhook Delivery endpoints
-- **2021-08-31** - Added PayID pool references to */contacts/receivable* and */bank_accounts* endpoints
-- **2021-07-01** - Added $1.65 amount for Sandbox simulated failures and minor tweaks
-- **2021-06-08** - Added Transfers, Payment Channel selection, Receivable Refunds
-- **2021-05-21** - Added new Payment Request endpoints, updated Postman collection
-- **2021-05-03** - Deprecated */payments_requests/outgoing* endpoint
-- **2021-04-20** - Removed deprecated API references, refreshed Refunds and Payout descriptions
-- **2021-03-17** - Remove note indicating single active bank account limitation
-- **2021-03-12** - Add ref to GetAContactResponse
-- **2021-02-24** - Added details on enabling the Receivable Contact feature and amended the POST/contacts/receivable response body
-- **2020-12-17** - Add Sandbox Only API endpoints
-- **2020-12-17** - Enhance response schema for several endpoints
-- **2020-12-16** - Add webhook schema table
-- **2020-12-15** - Improve webhooks section
-- **2020-12-15** - Re-word Payment Requests introduction to better cover its use with Receivable Contacts.
-- **2020-12-15** - Add changelog
+- NZ Changelogs will be added to this list once the application is deployed in New Zealand
 
-Looking for more? Our docs are open sourced! [https://github.com/zeptofs/api-documentation](https://github.com/zeptofs/api-documentation)
+Looking for more? Our docs are open sourced! [https://github.com/zeptofs/nz-api-documentation](https://github.com/zeptofs/nz-api-documentation)
 
 <h1 id="Zepto-API-Agreements">Agreements</h1>
 

--- a/source/openapi3/split.yaml
+++ b/source/openapi3/split.yaml
@@ -1485,48 +1485,10 @@ info:
     We take backwards compatibility seriously. The following list contains backwards compatible changes:
 
 
-    - **2022-01-21** - Reduced webhook delivery retries on sandbox to a single retry
-
-    - **2021-12-01** - Add ref to Webhook Delivery endpoint
-
-    - **2021-10-08** - Introduced improved transaction failure messaging (code, title and detail)
-
-    - **2021-09-29** - Added/expanded sandbox-only endpoints for simulating incoming payments
-
-    - **2021-09-08** - Added Webhooks and Webhook Delivery endpoints
-
-    - **2021-08-31** - Added PayID pool references to */contacts/receivable* and */bank_accounts* endpoints
-
-    - **2021-07-01** - Added $1.65 amount for Sandbox simulated failures and minor tweaks
-
-    - **2021-06-08** - Added Transfers, Payment Channel selection, Receivable Refunds
-
-    - **2021-05-21** - Added new Payment Request endpoints, updated Postman collection
-
-    - **2021-05-03** - Deprecated */payments_requests/outgoing* endpoint
-
-    - **2021-04-20** - Removed deprecated API references, refreshed Refunds and Payout descriptions
-
-    - **2021-03-17** - Remove note indicating single active bank account limitation
-
-    - **2021-03-12** - Add ref to GetAContactResponse
-
-    - **2021-02-24** - Added details on enabling the Receivable Contact feature and amended the POST/contacts/receivable response body
-
-    - **2020-12-17** - Add Sandbox Only API endpoints
-
-    - **2020-12-17** - Enhance response schema for several endpoints
-
-    - **2020-12-16** - Add webhook schema table
-
-    - **2020-12-15** - Improve webhooks section
-
-    - **2020-12-15** - Re-word Payment Requests introduction to better cover its use with Receivable Contacts.
-
-    - **2020-12-15** - Add changelog
+    - NZ Changelogs will be added to this list once the application is deployed in New Zealand
 
 
-    Looking for more? Our docs are open sourced! [https://github.com/zeptofs/api-documentation](https://github.com/zeptofs/api-documentation)
+    Looking for more? Our docs are open sourced! [https://github.com/zeptofs/nz-api-documentation](https://github.com/zeptofs/nz-api-documentation)
   version: '1.0'
 servers:
   - url: 'https://api.nz.sandbox.zepto.money'


### PR DESCRIPTION
I removed the old changelogs and left a placeholder in preparation for the changelogs in NZ (as NZ will be starting fresh with its own set of changelogs).

I also updated the github link to point to the NZ repository.

Before:

<img width="1017" alt="Screen Shot 2022-05-12 at 1 59 36 pm" src="https://user-images.githubusercontent.com/70265678/167989625-8c6695cb-151f-42a8-8331-f319a44cfcd0.png">

After:

<img width="973" alt="Screen Shot 2022-05-12 at 1 58 07 pm" src="https://user-images.githubusercontent.com/70265678/167989636-d4f3ed5a-0d9e-45da-a910-ceb1dc2e924d.png">

