### PR TITLE
ZEP-1939 Removed references to payment request receivables from refunds section

### DIFF
--- a/source/index.html.md
+++ b/source/index.html.md
@@ -5085,12 +5085,9 @@ Get a single payment by its reference
 
 <h1 id="Zepto-API-Refunds">Refunds</h1>
 
-Refunds can be issued for any successfully completed Payment Request transaction. This includes:
+Refunds can be issued for any successfully completed Payment Request transaction. This includes Payment Requests for direct debit payments.
 
-1. Payment Requests for direct debit payments **(Collections)**:
-2. Payment Requests for funds received via DE **(Receivables)**:
-
-This allows you to return any funds that were previously collected or received into one of your bank/float accounts.
+This allows you to return any funds that were previously collected or received into one of your bank accounts.
 
 ## Issue a Refund
 
@@ -5256,7 +5253,7 @@ func main() {
 
 Certain rules apply to the issuance of a refund:
 <ul>
-  <li>Must be applied against a successfully cleared Payment Request (Collections or Receivables)</li>
+  <li>Must be applied against a successfully cleared Payment Request</li>
   <li>Many refunds may be created against the original Payment Request</li>
   <li>The total refunded amount must not exceed the original value</li>
 </ul>

--- a/source/openapi3/split.yaml
+++ b/source/openapi3/split.yaml
@@ -1726,15 +1726,10 @@ tags:
   - name: Refunds
     description: >
 
-      Refunds can be issued for any successfully completed Payment Request transaction. This includes:
+      Refunds can be issued for any successfully completed Payment Request transaction. This includes Payment Requests for direct debit payments.
 
 
-      1. Payment Requests for direct debit payments **(Collections)**:
-
-      2. Payment Requests for funds received via DE **(Receivables)**:
-
-
-      This allows you to return any funds that were previously collected or received into one of your bank/float accounts.
+      This allows you to return any funds that were previously collected or received into one of your bank accounts.
   - name: Transactions
     description: >
       By default, the transactions endpoint provides a detailed look at all past, current
@@ -2581,7 +2576,7 @@ paths:
         Certain rules apply to the issuance of a refund:
 
         <ul>
-          <li>Must be applied against a successfully cleared Payment Request (Collections or Receivables)</li>
+          <li>Must be applied against a successfully cleared Payment Request</li>
           <li>Many refunds may be created against the original Payment Request</li>
           <li>The total refunded amount must not exceed the original value</li>
         </ul>


### PR DESCRIPTION
I removed any references to payment requests receivables from the Refunds section of the NZ docs.

I changed the numbered list into a sentence (as there is now only 1 item).

Before:

<img width="974" alt="Screen Shot 2022-05-12 at 2 12 34 pm" src="https://user-images.githubusercontent.com/70265678/167990854-0646d316-d2c5-45d2-8865-5fcc5d1bf6f6.png">

After:

<img width="974" alt="Screen Shot 2022-05-12 at 2 11 26 pm" src="https://user-images.githubusercontent.com/70265678/167990862-f1b9fd41-ca4e-4d2e-9372-5e39c3de51c1.png">

