### PR TITLE
ZEP-1940 Remove channel switch reference

### DIFF
--- a/source/index.html.md
+++ b/source/index.html.md
@@ -5687,7 +5687,6 @@ A transaction (debit or credit) can have the following statuses:
 | `pending_verification` | The bank account must be verified before the transaction can proceed. |
 | `paused` | The transaction has temporary been paused by Zepto pending internal review. |
 | `prefailed` | The transaction was never submitted to the bank because we detected that there were insufficient funds. The transaction can be retried. |
-| `channel_switched` | The initial payment channel has failed and the credit has automatically switched to attempt the payment using the next available channel. |
 ## Failure codes
 > Example response
 

--- a/source/openapi3/split.yaml
+++ b/source/openapi3/split.yaml
@@ -1786,9 +1786,6 @@ tags:
       detected that there were insufficient funds. The transaction can be
       retried. |
 
-      | `channel_switched` | The initial payment channel has failed and the credit has automatically
-      switched to attempt the payment using the next available channel. |
-
       ## Failure codes
 
       > Example response


### PR DESCRIPTION
The NZ application will only have 1 channel, therefore we do not need the channel_switched endpoint and we can remove the channel_switched references from the NZ docs.

Before:

<img width="995" alt="Screen Shot 2022-05-12 at 3 51 30 pm" src="https://user-images.githubusercontent.com/70265678/168001383-5f162559-396e-4241-ba47-43c290f25ec9.png">

After:

<img width="969" alt="Screen Shot 2022-05-12 at 3 49 56 pm" src="https://user-images.githubusercontent.com/70265678/168001398-8c4b4d64-7402-4ffb-a43c-457f130c9a92.png">
