### PR TITLE
ZEP-1981 Replace AU links with NZ coefficients

### DIFF
--- a/source/index.html.md
+++ b/source/index.html.md
@@ -1863,8 +1863,6 @@ Use this endpoint when you want to pay somebody.
       "account_number": "13048322",
       "bank_name": "Bank of New Zealand",
       "state": "active",
-      "iav_provider": null,
-      "iav_status": null,
       "blocks": {
         "debits_blocked": false,
         "credits_blocked": false
@@ -2050,8 +2048,6 @@ By default, all Contacts will be returned. You can apply filters to your query t
         "account_number": "494307",
         "bank_name": "Bank of New Zealand",
         "state": "active",
-        "iav_provider": "split",
-        "iav_status": "active",
         "blocks": {
           "debits_blocked": false,
           "credits_blocked": false
@@ -2071,8 +2067,6 @@ By default, all Contacts will be returned. You can apply filters to your query t
         "account_number": "4395959",
         "bank_name": "Bank of New Zealand",
         "state": "active",
-        "iav_provider": "split",
-        "iav_status": "credentials_invalid",
         "blocks": {
           "debits_blocked": false,
           "credits_blocked": false
@@ -2092,8 +2086,6 @@ By default, all Contacts will be returned. You can apply filters to your query t
         "account_number": null,
         "bank_name": null,
         "state": "disabled",
-        "iav_provider": null,
-        "iav_status": null,
         "blocks": {
           "debits_blocked": false,
           "credits_blocked": false
@@ -2113,8 +2105,6 @@ By default, all Contacts will be returned. You can apply filters to your query t
         "account_number": "13048322",
         "bank_name": "Bank of New Zealand",
         "state": "pending_verification",
-        "iav_provider": null,
-        "iav_status": null,
         "blocks": {
           "debits_blocked": false,
           "credits_blocked": false
@@ -2299,8 +2289,6 @@ Get a single Contact by its ID
       "account_number": "947434694",
       "bank_name": "Bank of New Zealand",
       "state": "active",
-      "iav_provider": null,
-      "iav_status": null,
       "blocks": {
         "debits_blocked": false,
         "credits_blocked": false
@@ -2693,8 +2681,6 @@ You can update the name, email, bank account and metadata of any Contact.
       "account_number": "99887766",
       "bank_name": "Zepto SANDBOX Bank",
       "state": "active",
-      "iav_provider": null,
-      "iav_status": null,
       "blocks": {
         "debits_blocked": false,
         "credits_blocked": false
@@ -8065,8 +8051,6 @@ Use this endpoint to resend a failed webhook delivery.
         "account_number": "494307",
         "bank_name": "Bank of New Zealand",
         "state": "active",
-        "iav_provider": "split",
-        "iav_status": "active",
         "blocks": {
           "debits_blocked": false,
           "credits_blocked": false
@@ -8086,8 +8070,6 @@ Use this endpoint to resend a failed webhook delivery.
         "account_number": "4395959",
         "bank_name": "Bank of New Zealand",
         "state": "active",
-        "iav_provider": "split",
-        "iav_status": "credentials_invalid",
         "blocks": {
           "debits_blocked": false,
           "credits_blocked": false
@@ -8107,8 +8089,6 @@ Use this endpoint to resend a failed webhook delivery.
         "account_number": null,
         "bank_name": null,
         "state": "disabled",
-        "iav_provider": null,
-        "iav_status": null,
         "blocks": {
           "debits_blocked": false,
           "credits_blocked": false
@@ -8128,8 +8108,6 @@ Use this endpoint to resend a failed webhook delivery.
         "account_number": "13048322",
         "bank_name": "Bank of New Zealand",
         "state": "pending_verification",
-        "iav_provider": null,
-        "iav_status": null,
         "blocks": {
           "debits_blocked": false,
           "credits_blocked": false
@@ -8198,8 +8176,6 @@ Use this endpoint to resend a failed webhook delivery.
       "account_number": "13048322",
       "bank_name": "Bank of New Zealand",
       "state": "active",
-      "iav_provider": null,
-      "iav_status": null,
       "blocks": {
         "debits_blocked": false,
         "credits_blocked": false
@@ -8278,8 +8254,6 @@ Use this endpoint to resend a failed webhook delivery.
       "account_number": "947434694",
       "bank_name": "Bank of New Zealand",
       "state": "active",
-      "iav_provider": null,
-      "iav_status": null,
       "blocks": {
         "debits_blocked": false,
         "credits_blocked": false
@@ -8320,8 +8294,6 @@ Use this endpoint to resend a failed webhook delivery.
 |»» id|string(uuid)|false|The Bank Account ID|
 |»» account_number|string|false|The Bank Account number (Min: 5 - Max: 9)|
 |»» state|string|false|The bank account state|
-|»» iav_provider|string|false|The instant account verification provider|
-|»» iav_status|string|false|The instant account verification bank connection status|
 |»» blocks|object|false|No description|
 |»»» debits_blocked|boolean|false|Used by Zepto admins. Defines whether the bank account is blocked from being debited|
 |»»» credits_blocked|boolean|false|Used by Zepto admins. Defined Whether this bank account is blocked from being credited|
@@ -8342,13 +8314,6 @@ Use this endpoint to resend a failed webhook delivery.
 |---|---|
 |state|active|
 |state|removed|
-|iav_provider|split|
-|iav_provider|proviso|
-|iav_provider|basiq|
-|iav_provider|credit_sense|
-|iav_status|active|
-|iav_status|removed|
-|iav_status|credentials_invalid|
 |state|pending|
 |state|active|
 |state|failed|
@@ -8401,8 +8366,6 @@ Use this endpoint to resend a failed webhook delivery.
       "account_number": "99887766",
       "bank_name": "Zepto SANDBOX Bank",
       "state": "active",
-      "iav_provider": null,
-      "iav_status": null,
       "blocks": {
         "debits_blocked": false,
         "credits_blocked": false

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -31,7 +31,7 @@ It is important to understand that there are 2 main ways Zepto can be used for m
 
 Due to the above, certain endpoints and techniques will differ slightly depending on who you are interacting with. You can find more on this in the [Making payments](/#making-payments) and [Getting paid](/#getting-paid) guides.
 
-And for all kinds of How To's and Recipes, head on over to our [Help Guide](https://help.split.cash/en/).
+And for all kinds of How To's and Recipes, head on over to our [Help Guide](https://help.zepto.money/en/).
 <div class="middle-header">Conventions</div>
 
 * Authentication is performed using OAuth2. See the [Get started](/#get-started) and [Authentication & Authorisation](/#authentication-and-authorisation) guides for more.
@@ -355,7 +355,7 @@ Common use cases:
 * Bill smoothing
 * Repayment plans
 
-Example flow embedding an [Open Agreement link](https://help.split.cash/agreements/open-agreement) using an iFrame in order to automate future Payment Request approvals:
+Example flow embedding an [Open Agreement link](https://help.zepto.money/en/articles/6210908-nz-open-agreement) using an iFrame in order to automate future Payment Request approvals:
 
 [![Hosted Open Agreement](https://raw.githubusercontent.com/zeptofs/public_assets/master/images/host_oa.png)](https://raw.githubusercontent.com/zeptofs/public_assets/master/images/host_oa.png)
 
@@ -370,7 +370,7 @@ Example flow embedding an [Open Agreement link](https://help.split.cash/agreemen
       "title": "Duplicate idempotency key",
       "detail": "A resource has already been created with this idempotency key",
       "links": {
-        "about": "https://docs.split.cash/"
+        "about": "https://docs.nz.zepto.money/"
       },
       "meta": {
         "resource_ref": "PB.1a4"
@@ -405,7 +405,7 @@ Keys expire after 24 hours. If there is a subsequent request with the same idemp
       "title": "A Specific Error",
       "detail": "Details about the error",
       "links": {
-        "about": "https://docs.split.cash/..."
+        "about": "https://docs.nz.zepto.money/..."
       }
     }
   ]
@@ -527,18 +527,6 @@ For example:
     * Initiate a Payment Request for <code>$2.03</code>.
     * Zepto will mimic a failure to debit the contact's bank account.
 
-## Instant account verification accounts
-When using any of our hosted solutions ([Payment Requests](https://help.split.cash/payment-requests/open-payment-requests), [Open Agreements](https://help.split.cash/agreements/open-agreement) or [Unassigned Agreements](http://help.split.cash/agreements/unassigned-agreement)) you may want to test the [Instant Account Verification (IAV)](http://help.split.cash/bank-accounts/instant-account-verification-iav) process where we accept online banking credentials to validate bank account access. To do so, you can use the following credentials:
-
-| Login | Password |
-|-------|----------|
-| `12345678` | `TestMyMoney` |
-
-<aside class="notice">The credentials will work with any of the available financial institutions.</aside>
-## Available balances in the Sandbox
-If your integration includes allowing us to pre-fail transactions prior to being processed, you may want to test that your system is handling these events correctly. A transaction will pre-fail when the available balance of the customers account is less than the amount of the payment being requested. This is checked during pre-processing just before your debit is sent for processing if there is an active bank connection.
-
-In the Sandbox environment, if the contact you are attempting to debit has a bank connection that was created through our Instant Account Verification feature, the available balance of any **Transactional** bank account will always be `$123.45`. Any payment requests above this amount will pre-fail and any amount less than or equal to this amount will succeed.
 # Configuration
 ## Scopes
 Scopes define the level of access granted via the OAuth2 authorisation process. As a best practice, only use the scopes your application will require.
@@ -626,7 +614,7 @@ Should you prefer debit aggregation to be disabled, please contact [support@zept
   ]
 }
 ```
-Please refer to our help centre [article on webhooks](http://help.split.cash/en/articles/3303626-webhooks) for more information and an overview of what you can achieve with webhooks.
+Please refer to our help centre [article on webhooks]( https://help.zepto.money/en/articles/6210952-nz-how-to-use-webhooks-with-your-api-integration) for more information and an overview of what you can achieve with webhooks.
 
 We support two main categories of webhooks:
 
@@ -917,7 +905,7 @@ Looking for more? Our docs are open sourced! [https://github.com/zeptofs/nz-api-
 An Agreement is an arrangement between two parties that allows them to agree on terms for which future Payment Requests will be auto-approved.
 
 Zepto Agreements are managed on a per Contact basis, and if a Payment Request is sent for an amount that exceeds the terms of the agreement, it will not be created.
-Please refer to the [What is an Agreement](http://help.split.cash/articles/3094575-what-is-an-agreement) article in our knowledge base for an overview.
+Please refer to the [What is an Agreement](https://help.zepto.money/en/articles/6210894-nz-agreements) article in our knowledge base for an overview.
 
 ##Lifecycle
 
@@ -2656,7 +2644,7 @@ You can update the name, email, bank account and metadata of any Contact.
   <ul>
     <li>Previous transactions to this Contact will retain the name and bank account that was used at the time.</li>
     <li>You cannot update a Contact's bank account details if they currently have an accepted agreement.</li>
-    <li>See our [Help Article](https://help.split.cash/en/articles/3829211-how-do-i-change-my-customers-bank-account-details) for more information about the nuances and implications of changing a contacts Bank Account.</li>
+    <li>See our [Help Article](https://help.zepto.money/en/articles/6239641-nz-how-do-i-change-my-customers-bank-account-details) for more information about the nuances and implications of changing a contacts Bank Account.</li>
   </ul>
 </aside>
 
@@ -5954,7 +5942,7 @@ An agreement with no preset authoriser that can only be accepted once and must b
 
 Unassigned Agreements are shared using the generated link available in the response body. You can then include it in an email, text message, embed it in an iFrame, etc...
 
-Please refer to the [Unassigned Agreement](http://help.split.cash/agreements/unassigned-agreement) article in our knowledge base for more information.
+Please refer to the [Unassigned Agreement](https://help.zepto.money/en/articles/6210903-nz-unassigned-agreement) article in our knowledge base for more information.
 
 ## Propose an Unassigned Agreement
 

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -614,7 +614,7 @@ Should you prefer debit aggregation to be disabled, please contact [support@zept
   ]
 }
 ```
-Please refer to our help centre [article on webhooks]( https://help.zepto.money/en/articles/6210952-nz-how-to-use-webhooks-with-your-api-integration) for more information and an overview of what you can achieve with webhooks.
+Please refer to our help centre [article on webhooks](https://help.zepto.money/en/articles/6210952-nz-how-to-use-webhooks-with-your-api-integration) for more information and an overview of what you can achieve with webhooks.
 
 We support two main categories of webhooks:
 

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -5590,7 +5590,6 @@ A transaction (debit or credit) can have the following statuses:
 | `voided` | The transaction has been cancelled and is no longer eligible for processing. |
 | `pending_verification` | The bank account must be verified before the transaction can proceed. |
 | `paused` | The transaction has temporary been paused by Zepto pending internal review. |
-| `prefailed` | The transaction was never submitted to the bank because we detected that there were insufficient funds. The transaction can be retried. |
 ## Failure codes
 > Example response
 
@@ -5625,7 +5624,7 @@ A transaction (debit or credit) can have the following statuses:
   ]
 }
 ```
-The rejected, returned, voided & prefailed statuses are always accompanied by a failure code, title and detail as listed below.
+The rejected, returned & voided statuses are always accompanied by a failure code, title and detail as listed below.
 ### DE credit failures
 | Code | Title | Detail |
 | ------------ | ------------- | -------------- |

--- a/source/openapi3/split.yaml
+++ b/source/openapi3/split.yaml
@@ -26,7 +26,7 @@ info:
 
 
     And for all kinds of How To's and Recipes, head on over to our
-    [Help Guide](https://help.split.cash/en/).
+    [Help Guide](https://help.zepto.money/en/).
 
     <div class="middle-header">Conventions</div>
 
@@ -503,7 +503,7 @@ info:
 
 
     Example flow embedding an [Open Agreement
-    link](https://help.split.cash/agreements/open-agreement) using an iFrame in
+    link](https://help.zepto.money/en/articles/6210908-nz-open-agreement) using an iFrame in
     order to automate future Payment Request approvals:
 
 
@@ -525,7 +525,7 @@ info:
           "title": "Duplicate idempotency key",
           "detail": "A resource has already been created with this idempotency key",
           "links": {
-            "about": "https://docs.split.cash/"
+            "about": "https://docs.nz.zepto.money/"
           },
           "meta": {
             "resource_ref": "PB.1a4"
@@ -586,7 +586,7 @@ info:
           "title": "A Specific Error",
           "detail": "Details about the error",
           "links": {
-            "about": "https://docs.split.cash/..."
+            "about": "https://docs.nz.zepto.money/..."
           }
         }
       ]
@@ -797,40 +797,6 @@ info:
         * Zepto will mimic a failure to debit the contact's bank account.
 
 
-    ## Instant account verification accounts
-
-    When using any of our hosted solutions ([Payment
-    Requests](https://help.split.cash/payment-requests/open-payment-requests),
-    [Open Agreements](https://help.split.cash/agreements/open-agreement) or
-    [Unassigned
-    Agreements](http://help.split.cash/agreements/unassigned-agreement)) you may
-    want to test the [Instant Account Verification
-    (IAV)](http://help.split.cash/bank-accounts/instant-account-verification-iav)
-    process where we accept online banking credentials to validate bank account
-    access. To do so, you can use the following credentials:
-
-
-    | Login | Password |
-
-    |-------|----------|
-
-    | `12345678` | `TestMyMoney` |
-
-
-    <aside class="notice">The credentials will work with any of the available
-    financial institutions.</aside>
-
-    ## Available balances in the Sandbox
-
-    If your integration includes allowing us to pre-fail transactions prior to being processed, you may want to test that your system is handling these events correctly.
-    A transaction will pre-fail when the available balance of the customers account is less than the amount of the payment being requested.
-    This is checked during pre-processing just before your debit is sent for processing if there is an active bank connection.
-
-
-    In the Sandbox environment, if the contact you are attempting to debit has a bank connection that was created through our Instant Account Verification feature, the
-    available balance of any **Transactional** bank account will always be `$123.45`. Any payment requests above this amount will pre-fail and any amount
-    less than or equal to this amount will succeed.
-
     # Configuration
 
     ## Scopes
@@ -976,7 +942,7 @@ info:
 
     ```
 
-    Please refer to our help centre [article on webhooks](http://help.split.cash/en/articles/3303626-webhooks) for more information and an overview of what you can achieve with webhooks.
+    Please refer to our help centre [article on webhooks]( https://help.zepto.money/en/articles/6210952-nz-how-to-use-webhooks-with-your-api-integration) for more information and an overview of what you can achieve with webhooks.
 
 
     We support two main categories of webhooks:
@@ -1451,7 +1417,7 @@ tags:
       Zepto Agreements are managed on a per Contact basis, and if a Payment Request
       is sent for an amount that exceeds the terms of the agreement, it will not be created.
 
-      Please refer to the [What is an Agreement](http://help.split.cash/articles/3094575-what-is-an-agreement) article in our knowledge base for an overview.
+      Please refer to the [What is an Agreement](https://help.zepto.money/en/articles/6210894-nz-agreements) article in our knowledge base for an overview.
 
 
       ##Lifecycle
@@ -1784,7 +1750,7 @@ tags:
       in an iFrame, etc...
 
 
-      Please refer to the [Unassigned Agreement](http://help.split.cash/agreements/unassigned-agreement)
+      Please refer to the [Unassigned Agreement](https://help.zepto.money/en/articles/6210903-nz-unassigned-agreement)
       article in our knowledge base for more information.
   - name: Users
     description: |
@@ -2066,7 +2032,7 @@ paths:
           <ul>
             <li>Previous transactions to this Contact will retain the name and bank account that was used at the time.</li>
             <li>You cannot update a Contact's bank account details if they currently have an accepted agreement.</li>
-            <li>See our [Help Article](https://help.split.cash/en/articles/3829211-how-do-i-change-my-customers-bank-account-details) for more information about the nuances and implications of changing a contacts Bank Account.</li>
+            <li>See our [Help Article](https://help.zepto.money/en/articles/6239641-nz-how-do-i-change-my-customers-bank-account-details) for more information about the nuances and implications of changing a contacts Bank Account.</li>
           </ul>
         </aside>
       operationId: UpdateAContact

--- a/source/openapi3/split.yaml
+++ b/source/openapi3/split.yaml
@@ -942,7 +942,7 @@ info:
 
     ```
 
-    Please refer to our help centre [article on webhooks]( https://help.zepto.money/en/articles/6210952-nz-how-to-use-webhooks-with-your-api-integration) for more information and an overview of what you can achieve with webhooks.
+    Please refer to our help centre [article on webhooks](https://help.zepto.money/en/articles/6210952-nz-how-to-use-webhooks-with-your-api-integration) for more information and an overview of what you can achieve with webhooks.
 
 
     We support two main categories of webhooks:

--- a/source/openapi3/split.yaml
+++ b/source/openapi3/split.yaml
@@ -3288,8 +3288,6 @@ components:
               account_number: '494307'
               bank_name: Bank of New Zealand
               state: active
-              iav_provider: split
-              iav_status: active
               blocks:
                 debits_blocked: false
                 credits_blocked: false
@@ -3304,8 +3302,6 @@ components:
               account_number: '4395959'
               bank_name: Bank of New Zealand
               state: active
-              iav_provider: split
-              iav_status: credentials_invalid
               blocks:
                 debits_blocked: false
                 credits_blocked: false
@@ -3320,8 +3316,6 @@ components:
               account_number: null
               bank_name: null
               state: disabled
-              iav_provider: null
-              iav_status: null
               blocks:
                 debits_blocked: false
                 credits_blocked: false
@@ -3336,8 +3330,6 @@ components:
               account_number: '13048322'
               bank_name: Bank of New Zealand
               state: pending_verification
-              iav_provider: null
-              iav_status: null
               blocks:
                 debits_blocked: false
                 credits_blocked: false
@@ -3391,8 +3383,6 @@ components:
             account_number: '13048322'
             bank_name: Bank of New Zealand
             state: active
-            iav_provider: null
-            iav_status: null
             blocks:
               debits_blocked: false
               credits_blocked: false
@@ -3480,21 +3470,6 @@ components:
                   enum:
                     - active
                     - removed
-                iav_provider:
-                  type: string
-                  description: The instant account verification provider
-                  enum:
-                    - split
-                    - proviso
-                    - basiq
-                    - credit_sense
-                iav_status:
-                  type: string
-                  description: The instant account verification bank connection status
-                  enum:
-                    - active
-                    - removed
-                    - credentials_invalid
                 blocks:
                   type: object
                   properties:
@@ -3560,8 +3535,6 @@ components:
             account_number: '947434694'
             bank_name: Bank of New Zealand
             state: active
-            iav_provider: null
-            iav_status: null
             blocks:
               debits_blocked: false
               credits_blocked: false
@@ -3620,8 +3593,6 @@ components:
             account_number: '99887766'
             bank_name: Zepto SANDBOX Bank
             state: active
-            iav_provider: null
-            iav_status: null
             blocks:
               debits_blocked: false
               credits_blocked: false

--- a/source/openapi3/split.yaml
+++ b/source/openapi3/split.yaml
@@ -1629,10 +1629,6 @@ tags:
       | `paused` | The transaction has temporary been paused by Zepto pending
       internal review. |
 
-      | `prefailed` | The transaction was never submitted to the bank because we
-      detected that there were insufficient funds. The transaction can be
-      retried. |
-
       ## Failure codes
 
       > Example response
@@ -1672,7 +1668,7 @@ tags:
 
       ```
 
-      The rejected, returned, voided & prefailed statuses are always accompanied by a failure code, title and detail as listed below.
+      The rejected, returned & voided statuses are always accompanied by a failure code, title and detail as listed below.
 
       ### DE credit failures
 


### PR DESCRIPTION
Since some the processes are different within NZ, we need to update the links that point to processes / guides that are different in NZ to use guides that are the NZ equivalent. 

I also came across content which involved IAV / pre-fails - which I removed as IAV is not available within NZ.

### BEFORE

**Testing Sandbox Details > Instant Account Verification Accounts:**

![Screen Shot 2022-05-23 at 11 46 10 am](https://user-images.githubusercontent.com/70265678/169728138-05dc1eb4-38de-420d-ad2f-1bc5d2d680fa.png)

**Sample Responses:**

![Screen Shot 2022-05-23 at 11 48 46 am](https://user-images.githubusercontent.com/70265678/169728480-400fc546-9bfb-4d89-a9bc-65bfa5d700bb.png)

**Transactions > Lifecycle:**

![Screen Shot 2022-05-23 at 11 25 47 am](https://user-images.githubusercontent.com/70265678/169728746-49ed805a-7385-4358-afa5-a582ab18b68b.png)


### AFTER

**Testing Sandbox Details (Instant Account Verification Accounts Section removed):**

![Screen Shot 2022-05-23 at 11 46 51 am](https://user-images.githubusercontent.com/70265678/169728181-b05c2a2f-2074-4028-a0c3-679efff412ba.png)

**Sample Responses (Removed IAV fields from sample response examples):**

![Screen Shot 2022-05-23 at 11 50 20 am](https://user-images.githubusercontent.com/70265678/169728472-66d72aac-8553-494b-b2b1-b52ac37d5c2d.png)

**Transactions > Lifecycle (prefailed status removed, and reference to prefail removed):**

![Screen Shot 2022-05-23 at 11 51 48 am](https://user-images.githubusercontent.com/70265678/169728710-02c626ed-0eb0-4084-94ed-1b23748cfbc7.png)

