### PR TITLE
Update docs to include idempotency hints for relevant requests

### DIFF
--- a/source/openapi3/split.yaml
+++ b/source/openapi3/split.yaml
@@ -532,7 +532,9 @@ info:
 
     For example, if a [Payment](#Zepto-API-Payments) is `POST`ed and a there is
     a network connection error, you can retry the Payment with the same
-    idempotency key to guarantee that only a single Payment is created.
+    idempotency key to guarantee that only a single Payment is created. 
+    In case an idempotency key is not supplied and a Payment is retried, 
+    we would treat this as two different payments being made.
 
 
     To perform an idempotent request, provide an additional `Idempotency-Key:
@@ -560,6 +562,18 @@ info:
     * A request that quickly follows another with the same idempotency key may return
     with `503 Service Unavailable`. If so, retry the request after the number of seconds
     specified in the `Retry-After` response header.
+
+
+    Currently the following `POST` requests can be made idempotent. 
+    We **strongly recommend** sending a unique `Idempotency-Key` header 
+    when making those requests to allow for safe retries:
+
+
+    * [Request Payment](/#request-payment)
+
+    * [Make a Payment](/#make-a-payment)
+
+    * [Issue a Refund](/#issue-a-refund)
 
 
     ## Error responses
@@ -2040,8 +2054,17 @@ paths:
       tags:
         - Payments
       summary: Make a Payment
-
+      description: >
+        <aside class="notice">We strongly recommend to supply an <code>Idempotency-Key</code> header when performing this request to ensure you can safely retry the action in case of an issue. If a header value is omitted or is different to one provided previously, we will be treating a request as a new operation which may lead to duplicate payments. To understand more on how to make idempotent requests, please refer to our <a href="#idempotent-requests">Idempotent requests guide</a>.</aside>
       operationId: MakeAPayment
+      parameters:
+        - name: 'Idempotency-Key'
+          in: header
+          description: 'Idempotency key to support safe retries for 24h'
+          required: false
+          schema:
+            type: string
+          example: '{unique-uuid-per-payment}'
       requestBody:
         description: ''
         content:
@@ -2112,9 +2135,17 @@ paths:
       tags:
         - Payment Requests
       summary: Request Payment
-      description: ''
+      description: >
+        <aside class="notice">We strongly recommend to supply an <code>Idempotency-Key</code> header when performing this request to ensure you can safely retry the action in case of an issue. If a header value is omitted or is different to one provided previously, we will be treating a request as a new operation which may lead to a duplicate funds collection. To understand more on how to make idempotent requests, please refer to our <a href="#idempotent-requests">Idempotent requests guide</a>.</aside>
       operationId: MakeAPaymentRequest
-      parameters: []
+      parameters:
+        - name: 'Idempotency-Key'
+          in: header
+          description: 'Idempotency key to support safe retries for 24h'
+          required: false
+          schema:
+            type: string
+          example: '{unique-uuid-per-payment-request}'
       requestBody:
         description: ''
         content:
@@ -2218,8 +2249,17 @@ paths:
           <li>Many refunds may be created against the original Payment Request</li>
           <li>The total refunded amount must not exceed the original value</li>
         </ul>
+
+        <aside class="notice">We strongly recommend to supply an <code>Idempotency-Key</code> header when performing this request to ensure you can safely retry the action in case of an issue. If a header value is omitted or is different to one provided previously, we will be treating a request as a new operation which may lead to duplicate refunds. To understand more on how to make idempotent requests, please refer to our <a href="#idempotent-requests">Idempotent requests guide</a>.</aside>
       operationId: IssueARefund
       parameters:
+        - name: 'Idempotency-Key'
+          in: header
+          description: 'Idempotency key to support safe retries for 24h'
+          required: false
+          schema:
+            type: string
+          example: '{unique-uuid-per-refund}'
         - name: credit_ref
           in: path
           description: 'The credit reference number e.g C.625v'


### PR DESCRIPTION
- [Trello card](https://trello.com/c/OYoTZRmr/134-idempotency-key-docs-for-nz-docs)

When looking at idempotency key details and the api docs, we have noticed that the docs do not state explicitly which requests support idemponecy feature and we do not link from those requests back to the idempotent requests guide. 

As a result, we have decided to extend the docs to make sure it is explicit which API requests support `Idempotency-Key` header to ensure safe re-tries.


## What is in this PR?

- extend te section to outline the negative scenario: 
![image](https://user-images.githubusercontent.com/102490628/175178610-2a744df4-8d51-4ade-827d-d16573d82295.png)
- include the following section as part of the "Idempotent requests" guide:
![image](https://user-images.githubusercontent.com/102490628/174936141-4a2c493b-72b6-4847-83b6-4ace004b99d8.png)
- include the following info box calling out to add idempotency header \ in "Make a payment", "Request Payment" and "Issue a Refund" request docs:
![image](https://user-images.githubusercontent.com/102490628/174936198-44256e0c-58b8-4bdd-a531-38b15a4451f1.png)
![image](https://user-images.githubusercontent.com/102490628/174936244-850884b6-f21a-42a4-8577-8dc95b522626.png)
![image](https://user-images.githubusercontent.com/102490628/174936285-7f2fb60b-4bbb-453d-adf5-86a7c030c6ee.png)
- extend params for each relevant requests to include non-required Idempotency-key header which propagates to examples: 
![image](https://user-images.githubusercontent.com/102490628/175178717-6a8e3567-db7a-45c3-9506-a8a1c1dea1e9.png)
![image](https://user-images.githubusercontent.com/102490628/175178738-1443e4a4-c7ab-4da9-8369-d83b5590dd69.png)
![image](https://user-images.githubusercontent.com/102490628/175178784-61525ee3-099e-4b91-8d29-57975dc2ff62.png)

